### PR TITLE
Handle SNMP SET on an Integer type value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'java'
 mainClassName = 'snmp.Main'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
-version = '0.1.14'
+version = '0.1.15'
 
 repositories {
     mavenCentral()

--- a/dslink.json
+++ b/dslink.json
@@ -1,6 +1,6 @@
 {
   "name": "dslink-java-snmp",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A dslink for snmp",
   "license": "GNU GPL",
   "main": "bin/dslink-java-snmp",

--- a/src/main/java/snmp/SnmpNode.java
+++ b/src/main/java/snmp/SnmpNode.java
@@ -324,7 +324,7 @@ public class SnmpNode {
 			Value syntax = vnode.getAttribute("syntax");
 			if (oid == null || syntax == null)
 				return;
-			String valstring = event.getCurrent().getString();
+			String valstring = event.getCurrent().toString();
 			int syntaxInt = syntax.getNumber().intValue();
 			if (syntaxInt == SMIConstants.SYNTAX_NULL)
 				return;


### PR DESCRIPTION
The string value for the number was fetched incorrectly. Instead of Value.getString(), we should use Value.toString() method. 